### PR TITLE
docs: add contributor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# arb-portfolio
+
+Utilities for analyzing token and transaction data on Arbitrum. The repository currently hosts an importer CLI that reads CSV files and produces a normalized transactions file.
+
+## Documentation
+
+Detailed setup and contribution guides are available in the [docs](docs/README.md) directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Project Documentation
+
+Welcome to the documentation for **arb-portfolio**. This folder provides guidance for setting up a development environment and contributing to the project.
+
+## Contents
+
+- [Development Setup](development.md): Install prerequisites, build, and run tests.
+- [Contributing Guide](contributing.md): Workflow and coding conventions for patches.
+
+If you are new to the repository, start with the [Development Setup](development.md) guide.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,29 @@
+# Contributing Guide
+
+Thank you for considering a contribution to **arb-portfolio**. This guide explains the workflow and conventions expected for patches.
+
+## Workflow
+
+1. Fork the repository and create your feature branch.
+2. Make your changes and ensure they follow the coding conventions below.
+3. Run `cargo fmt` and `cargo test` to verify formatting and ensure tests pass.
+4. Commit your changes with a descriptive message.
+5. Open a pull request describing your changes.
+
+## Coding Conventions
+
+- Code is formatted with `rustfmt`. Run `cargo fmt --all` before committing.
+- Keep functions and modules focused. Prefer small, composable functions over large ones.
+- Include unit tests for new features when possible.
+
+## Commit Messages
+
+Use present tense and keep the first line under 50 characters, e.g.:
+
+```
+docs: add contributing guide
+```
+
+## Questions
+
+If you have any questions, open an issue or start a discussion in the repository.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,33 @@
+# Development Setup
+
+## Prerequisites
+
+- [Rust](https://www.rust-lang.org/): This project uses the Rust toolchain. Install using [`rustup`](https://rustup.rs/).
+
+## Building the Project
+
+Clone the repository and build the workspace:
+
+```bash
+git clone <repo-url>
+cd arb-portfolio
+cargo build
+```
+
+## Running Tests
+
+Before submitting changes, make sure all tests pass:
+
+```bash
+cargo test
+```
+
+## Running the Importer CLI
+
+The repository contains a CLI for processing token and transaction data. To run it:
+
+```bash
+cargo run --bin run -- --address <ARBITRUM_ADDRESS>
+```
+
+Replace `<ARBITRUM_ADDRESS>` with the address you would like to analyze. Input CSV files are expected under the `data/ingest` directory.

--- a/importer/src/bin/run.rs
+++ b/importer/src/bin/run.rs
@@ -1,7 +1,9 @@
+//! Command line interface for converting raw CSV exports into normalized transactions.
+
 use clap::Parser;
 use std::error::Error;
 use arb_portfolio::{
-  Transfer, read_tokens, read_transactions, write_csv, Transaction,
+  read_tokens, read_transactions, write_csv, Transaction, Transfer,
 };
 use arb_portfolio::transaction::ToTransaction;
 
@@ -16,6 +18,7 @@ struct Args {
 
 const ADDRESS: &str = "0x0A8Dd68E974C371A6a6Efe95cfA22a200eb7AfCc";
 
+/// Runs the importer CLI.
 fn main() -> Result<(), Box<dyn Error>> {
     // initialize logging from log4rs config file
     log4rs::init_file("log4rs.yml", Default::default()).expect("failed to init logger");

--- a/importer/src/ingest/mod.rs
+++ b/importer/src/ingest/mod.rs
@@ -1,3 +1,4 @@
+//! CSV ingestion helpers for tokens and transactions.
 
 pub mod token;
 pub mod transaction;

--- a/importer/src/ingest/token.rs
+++ b/importer/src/ingest/token.rs
@@ -1,9 +1,12 @@
-use serde::{Deserialize};
-use crate::{Transfer, Token as TokenMeta, read_csv};
+//! Functions for ingesting token transfer CSVs exported from Etherscan.
+
+use serde::Deserialize;
+use crate::{read_csv, Token as TokenMeta, Transfer};
 use rust_decimal::Decimal;
 use std::error::Error;
 use std::str::FromStr;
 
+/// Converts a raw CSV token transfer and the account address into a normalized [`Transfer`].
 impl From<(&str, Token)> for Transfer {
     fn from((address, event): (&str, Token)) -> Self {
         let value = match Decimal::from_str(&event.token_value.replace(",", "")) {
@@ -29,12 +32,15 @@ impl From<(&str, Token)> for Transfer {
     }
 }
 
+/// Reads a token transfer CSV and converts each row into a [`Transfer`] for the
+/// provided address.
 pub fn read_tokens(file_path: &str, address: &'static str) -> Result<Vec<Transfer>, Box<dyn Error>> {
     Ok(read_csv::<Token>(file_path)?.into_iter().map(|x| (address, x).into()).collect())
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")] // Automatically handles camel case, e.g., "Transaction Hash" -> "TransactionHash"
+/// Raw representation of a token transfer row as exported by Etherscan.
 pub struct Token {
     #[serde(rename = "Transaction Hash")]
     pub transaction_hash: String,

--- a/importer/src/ingest/transaction.rs
+++ b/importer/src/ingest/transaction.rs
@@ -1,9 +1,12 @@
-use serde::{Deserialize};
-use crate::{Transfer, Token, read_csv};
+//! Functions for ingesting normal transaction CSVs exported from Etherscan.
+
+use serde::Deserialize;
+use crate::{read_csv, Token, Transfer};
 use rust_decimal::Decimal;
 use std::error::Error;
 use std::str::FromStr;
 
+/// Converts a CSV transaction row into a [`Transfer`] capturing its ETH movement.
 impl From<(&str, Transaction)> for Transfer {
     fn from((_address, tx): (&str, Transaction)) -> Self {
         let value = Decimal::from_str(&tx.value_in_eth).ok();
@@ -23,12 +26,15 @@ impl From<(&str, Transaction)> for Transfer {
     }
 }
 
+/// Reads a transaction CSV and converts each row into a [`Transfer`] for the
+/// supplied address.
 pub fn read_transactions(file_path: &str, address: &'static str) -> Result<Vec<Transfer>, Box<dyn Error>> {
     Ok(read_csv::<Transaction>(file_path)?.into_iter().map(|x| (address, x).into()).collect())
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+/// Raw representation of an Etherscan transaction export.
 pub struct Transaction {
     #[serde(rename = "Txhash")]
     pub txhash: String,

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -1,11 +1,12 @@
+//! Library utilities for reading, normalizing and classifying blockchain data.
+
 mod read_csv;
 pub use read_csv::{read_csv, write_csv};
 pub mod category;
 pub mod token;
 
 mod types;
-pub use types::{Transfer, Transaction, TransactionCategory, SwapSubCategory, Token};
-
+pub use types::{SwapSubCategory, Token, Transaction, TransactionCategory, Transfer};
 
 pub mod ingest;
 pub use ingest::token::read_tokens;

--- a/importer/src/read_csv.rs
+++ b/importer/src/read_csv.rs
@@ -1,8 +1,10 @@
+//! Lightweight wrappers around the [`csv`] crate for reading and writing data.
+
 use csv::ReaderBuilder;
 use csv::WriterBuilder;
 use serde::Deserialize;
-use std::error::Error;
 use serde::Serialize;
+use std::error::Error;
 
 /// Generic function to read CSV into a vector of structs.
 pub fn read_csv<T>(file_path: &str) -> Result<Vec<T>, Box<dyn Error>>
@@ -24,6 +26,7 @@ where
     Ok(records)
 }
 
+/// Writes a slice of serializable records to a CSV file without headers.
 pub fn write_csv<T>(t: &[T], file_path: &str) -> Result<(), Box<dyn Error>>
 where
     T: Serialize, // Ensures that T can be serialized

--- a/importer/src/transaction.rs
+++ b/importer/src/transaction.rs
@@ -1,15 +1,19 @@
-use crate::{Transfer, Transaction, TransactionCategory};
+//! Conversion logic for grouping raw [`Transfer`]s into higher level [`Transaction`] records.
+
+use crate::{Transaction, TransactionCategory, Transfer};
 use std::collections::HashMap;
 use std::collections::HashSet;
-use rust_decimal::Decimal;
 use std::str::FromStr;
 
-// Implement a custom trait for conversion
+use rust_decimal::Decimal;
+
+/// Convert intermediate types into a collection of [`Transaction`]s.
 pub trait ToTransaction {
+    /// Consumes the implementor and returns a set of [`Transaction`] values.
     fn to_transaction(self) -> Vec<Transaction>;
 }
 
-// Implement From<Transaction> for Transfer
+/// Groups a list of [`Transfer`]s by their identifier to build [`Transaction`]s.
 impl ToTransaction for Vec<Transfer> {
     fn to_transaction(self) -> Vec<Transaction> {
       let mut transaction_map: HashMap<String, Vec<Transfer>> = HashMap::new();

--- a/importer/src/types.rs
+++ b/importer/src/types.rs
@@ -1,56 +1,90 @@
+//! Core data structures shared across the importer.
+
 use serde::Serialize;
 use rust_decimal::Decimal;
 
 #[derive(Default, Debug, Serialize, PartialEq)]
+/// Granular classification for swap transactions.
 pub enum SwapSubCategory {
-  Simple, // Single Asset, Single USD(C)
-  MultiAsset, // Multi Asset, No USD(C)
+  /// A simple two-leg swap where one side has a stable USD value.
+  Simple,
+  /// Swaps involving multiple assets without a stable USD leg.
+  MultiAsset,
+  /// Unable to determine the swap type.
   #[default]
   UnknownSwap,
 }
 
 #[derive(Default, Debug, Serialize, PartialEq)]
+/// High level category describing the nature of a [`Transaction`].
 pub enum TransactionCategory {
-  Swap(SwapSubCategory), // AAVE and Swap
-  Trade, // GMX
-  Transfer, // Transfers
+  /// Automated market-maker swap (e.g. AAVE).
+  Swap(SwapSubCategory),
+  /// Perpetual or spot trade (e.g. GMX).
+  Trade,
+  /// Simple transfer of value between accounts.
+  Transfer,
+  /// Airdropped tokens received without cost.
   Airdrop,
+  /// Activity that should be ignored in reports.
   Ignore,
+  /// Unknown or unclassified activity.
   #[default]
   Unknown,
 }
 
 #[derive(Debug, Serialize)]
+/// Grouped representation of on-chain activity consisting of one or more [`Transfer`]s.
 pub struct Transaction {
+  /// Identifier shared across the underlying transfers.
   pub transfer_id: String,
+  /// ISO8601 timestamp of the transaction.
   pub datetime: String,
+  /// Classification of the transaction.
   pub category: TransactionCategory,
+  /// Total USD cost basis for the transaction.
   pub cost_basis: Decimal,
+  /// Pipe-separated list of unique assets involved.
   pub assets: String,
+  /// Net value moved by the transaction.
   pub value: Decimal,
+  /// Source transfers that compose this transaction.
   #[serde(skip_serializing)]
   pub transfer: Vec<Transfer>,
+  /// Number of individual transfers contained.
   pub n: usize,
 }
 
-
 #[derive(Debug, Serialize, Clone)]
+/// Normalized representation of an ERC-20 token.
 pub struct Token {
+  /// Human readable name of the asset.
   pub asset: String,
+  /// Short ticker symbol.
   pub symbol: String,
+  /// Optional USD value for one token.
   pub stable_usd_value: Option<Decimal>,
+  /// Contract address for the token.
   #[serde(skip_serializing)]
-  pub address: String
+  pub address: String,
 }
 
 #[derive(Debug, Serialize)]
+/// Individual movement of a token value between two addresses.
 pub struct Transfer {
+  /// Unique identifier used to group related transfers.
   pub transfer_id: String,
+  /// ISO8601 timestamp of the transfer.
   pub datetime: String,
+  /// Token being transferred.
   pub token: Token,
+  /// Amount of token moved, positive for incoming and negative for outgoing.
   pub value: Option<Decimal>,
+  /// Sender address.
   #[serde(skip_serializing)]
   pub from: String,
+  /// Recipient address.
   #[serde(skip_serializing)]
   pub to: String,
 }
+


### PR DESCRIPTION
## Summary
- add docs directory with development and contributing guides
- describe project and link docs from README
- document core data types, traits, and ingestion helpers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6893639da1ec832bab3cd3e88b6fb602