### PR TITLE
Add optional USD value for transfers

### DIFF
--- a/importer/src/ingest/token.rs
+++ b/importer/src/ingest/token.rs
@@ -16,6 +16,8 @@ impl From<(&str, Token)> for Transfer {
           _ => panic!(),
         };
 
+        let usd_value = Decimal::from_str(&event.usd_value_day_of_tx.replace(",", "").replace("$", "")).ok();
+
         let token: TokenMeta = (&event.contract_address).into();
 
         Transfer {
@@ -26,6 +28,7 @@ impl From<(&str, Token)> for Transfer {
             address: event.contract_address,
             symbol: event.token_symbol,*/
             value,
+            usd_value,
             from: event.from,
             to: event.to,
         }

--- a/importer/src/ingest/transaction.rs
+++ b/importer/src/ingest/transaction.rs
@@ -10,6 +10,7 @@ use std::str::FromStr;
 impl From<(&str, Transaction)> for Transfer {
     fn from((_address, tx): (&str, Transaction)) -> Self {
         let value = Decimal::from_str(&tx.value_in_eth).ok();
+        let usd_value = Decimal::from_str(&tx.current_value).ok();
         Transfer {
             transfer_id: tx.txhash,
             datetime: tx.datetime_utc.to_string(),
@@ -20,6 +21,7 @@ impl From<(&str, Transaction)> for Transfer {
               stable_usd_value: None,
             },
             value,
+            usd_value,
             from: tx.from,
             to: tx.to,
         }

--- a/importer/src/types.rs
+++ b/importer/src/types.rs
@@ -80,6 +80,8 @@ pub struct Transfer {
   pub token: Token,
   /// Amount of token moved, positive for incoming and negative for outgoing.
   pub value: Option<Decimal>,
+  /// USD value of the transfer at the time of the transaction.
+  pub usd_value: Option<Decimal>,
   /// Sender address.
   #[serde(skip_serializing)]
   pub from: String,


### PR DESCRIPTION
## Summary
- track optional USD value on `Transfer`
- parse USD amounts from token and transaction CSVs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68936d76a778832bb76b9c93a4338a8d